### PR TITLE
fix: detect REST context when using plain-permalink ?rest_route= routing

### DIFF
--- a/src/Core/Context.php
+++ b/src/Core/Context.php
@@ -160,16 +160,12 @@ final class XWP_Context {
     /**
      * Check if the request is a REST request.
      *
-     * Handles both pretty-permalink requests (REQUEST_URI contains /wp-json/)
-     * and plain-permalink requests routed via the ?rest_route= query var.
-     *
      * @return bool
      */
     public static function rest(): bool {
         $prefix = \trailingslashit( \rest_get_url_prefix() );
 
-        return false !== \strpos( \xwp_fetch_server_var( 'REQUEST_URI', '' ), $prefix )
-            || ! empty( $_GET['rest_route'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        return false !== \strpos( \xwp_fetch_server_var( 'REQUEST_URI', '' ), $prefix ) || ! empty( \xwp_fetch_get_var('rest_route') );
     }
 
     /**

--- a/src/Core/Context.php
+++ b/src/Core/Context.php
@@ -160,12 +160,16 @@ final class XWP_Context {
     /**
      * Check if the request is a REST request.
      *
+     * Handles both pretty-permalink requests (REQUEST_URI contains /wp-json/)
+     * and plain-permalink requests routed via the ?rest_route= query var.
+     *
      * @return bool
      */
     public static function rest(): bool {
         $prefix = \trailingslashit( \rest_get_url_prefix() );
 
-        return false !== \strpos( \xwp_fetch_server_var( 'REQUEST_URI', '' ), $prefix );
+        return false !== \strpos( \xwp_fetch_server_var( 'REQUEST_URI', '' ), $prefix )
+            || ! empty( $_GET['rest_route'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
     }
 
     /**


### PR DESCRIPTION
WordPress routes REST API requests via `?rest_route=/...` when pretty permalinks are disabled (e.g. fresh wp-env installs, many CI environments).

`XWP_Context::rest()` only checked REQUEST_URI for the /wp-json/ prefix, so plain-permalink REST requests were never detected as REST context. This caused all DI handlers with `context: CTX_REST` to be skipped, returning 404 for every REST endpoint.

Add a secondary check for the `rest_route` query var to cover this path.